### PR TITLE
handle buses not having a platform number

### DIFF
--- a/lib/time_table.rb
+++ b/lib/time_table.rb
@@ -61,7 +61,7 @@ class TimeTable
   def unique(*list)
     uniques = Hash.new(0)
     self.hash['services'].each { |service| uniques.store(service.dig(*list), uniques[service.dig(*list)] + 1) }
-    uniques.sort
+    uniques.sort_by &:to_s # @TODO this'll do weird things for numbers
   end
 
   def dig(*path)


### PR DESCRIPTION
Buses do not have a platform number, they simply don't have the platform key in the json.  This means sorting by unique platforms fails because it is attempting to perform comparison on nil.

This is easily fixed by coercing values into strings in the sort, but still won't sort platforms correctly because of the way they're formatted.  It at least lets us display stations where buses are running though.