### PR TITLE
initial commit of a tool to archive LDS-specific station data to S3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ csv
 tmp
 dump
 .idea
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'puma'
 gem 'sinatra-flash'
 gem 'redis'
 gem 'twitter'
+gem 'aws-sdk'
 
 group :test do
   gem 'rack-test'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,12 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.4.0)
+    aws-sdk (2.4.3)
+      aws-sdk-resources (= 2.4.3)
+    aws-sdk-core (2.4.3)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.4.3)
+      aws-sdk-core (= 2.4.3)
     buftok (0.2.0)
     diff-lcs (1.2.5)
     domain_name (0.5.20160615)
@@ -21,6 +27,7 @@ GEM
     httparty (0.13.7)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
+    jmespath (1.3.1)
     json (1.8.3)
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
@@ -77,6 +84,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk
   httparty
   json
   minitest
@@ -89,5 +97,8 @@ DEPENDENCIES
   sinatra-flash
   twitter
 
+RUBY VERSION
+   ruby 2.2.4p230
+
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/archive.rb
+++ b/archive.rb
@@ -1,9 +1,15 @@
+require_relative 'lib/time_table.rb'
 require 'aws-sdk'
+require 'date'
+
+run_date = Date.today.prev_day
+timetable = TimeTable.new(run_date, 'LDS')
+
 
 s3 = Aws::S3::Resource.new(region: 'eu-west-1')
 environment = ENV['RACK_ENV'] || 'development'
 
-LDS = Dir.glob("tmp/#{environment}/LDS-*.json")
+LDS = Dir.glob("tmp/#{environment}/LDS-#{run_date.to_s}.json")
 LDS.each do |day|
   s3.bucket('leedstrains').object(File.basename(day)).upload_file(day)
 end

--- a/archive.rb
+++ b/archive.rb
@@ -1,0 +1,10 @@
+require 'aws-sdk'
+
+s3 = Aws::S3::Resource.new(region: 'eu-west-1')
+environment = ENV['RACK_ENV'] || 'development'
+
+LDS = Dir.glob("tmp/#{environment}/LDS-*.json")
+LDS.each do |day|
+  s3.bucket('leedstrains').object(File.basename(day)).upload_file(day)
+end
+


### PR DESCRIPTION
This is pretty simple and just uploads all the LDS-specific data from the tmp directory.  It needs you to retrieve the data by browsing the website before running this tool.

I should probably either tag this onto the end of the daily tweet script or do a download and schedule it separately.